### PR TITLE
Add right-click trigger for reactions/context menu on desktop & web

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -125,6 +125,7 @@ class _ChatScreenState extends State<ChatScreen> {
                       enableHapticFeedback: true,
                       maxReactionsToShow: 3,
                       enableDoubleTap: true,
+                      onSecondaryTapDown: true,
                       //customMenuItemBuilder: _customMenuItemBuilder,
                     );
                     return ChatMessageWrapper(

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -125,7 +125,7 @@ class _ChatScreenState extends State<ChatScreen> {
                       enableHapticFeedback: true,
                       maxReactionsToShow: 3,
                       enableDoubleTap: true,
-                      onSecondaryTapDown: true,
+                      enableRightClick: true,
                       //customMenuItemBuilder: _customMenuItemBuilder,
                     );
                     return ChatMessageWrapper(

--- a/lib/src/models/chat_reactions_config.dart
+++ b/lib/src/models/chat_reactions_config.dart
@@ -10,7 +10,7 @@ class ChatReactionsConfig {
   final bool showAddReactionButton;
   final bool enableHapticFeedback;
   final bool enableLongPress;
-  final bool onSecondaryTapDown;
+  final bool enableRightClick;
   final bool enableDoubleTap;
   final int maxReactionsToShow;
   final double reactionSize;

--- a/lib/src/models/chat_reactions_config.dart
+++ b/lib/src/models/chat_reactions_config.dart
@@ -10,6 +10,7 @@ class ChatReactionsConfig {
   final bool showAddReactionButton;
   final bool enableHapticFeedback;
   final bool enableLongPress;
+  final bool onSecondaryTapDown;
   final bool enableDoubleTap;
   final int maxReactionsToShow;
   final double reactionSize;
@@ -39,6 +40,7 @@ class ChatReactionsConfig {
     this.enableHapticFeedback = true,
     this.enableLongPress = true,
     this.enableDoubleTap = false,
+    this.onSecondaryTapDown = false,
     this.maxReactionsToShow = 5,
     this.reactionSize = 25.0,
     this.stackedValue = 4.0,

--- a/lib/src/models/chat_reactions_config.dart
+++ b/lib/src/models/chat_reactions_config.dart
@@ -40,7 +40,7 @@ class ChatReactionsConfig {
     this.enableHapticFeedback = true,
     this.enableLongPress = true,
     this.enableDoubleTap = false,
-    this.onSecondaryTapDown = false,
+    this.enableRightClick = false,
     this.maxReactionsToShow = 5,
     this.reactionSize = 25.0,
     this.stackedValue = 4.0,

--- a/lib/src/widgets/chat_message_wrapper.dart
+++ b/lib/src/widgets/chat_message_wrapper.dart
@@ -95,7 +95,7 @@ class ChatMessageWrapper extends StatelessWidget {
           config.enableLongPress ? () => _showReactionsDialog(context) : null,
       onDoubleTap:
           config.enableDoubleTap ? () => _showReactionsDialog(context) : null,
-      onSecondaryTapDown: config.onSecondaryTapDown
+      onSecondaryTapDown: config.enableRightClick
           ? (_) => _showReactionsDialog(context)
           : null,
       child: Hero(

--- a/lib/src/widgets/chat_message_wrapper.dart
+++ b/lib/src/widgets/chat_message_wrapper.dart
@@ -95,6 +95,9 @@ class ChatMessageWrapper extends StatelessWidget {
           config.enableLongPress ? () => _showReactionsDialog(context) : null,
       onDoubleTap:
           config.enableDoubleTap ? () => _showReactionsDialog(context) : null,
+      onSecondaryTapDown: config.onSecondaryTapDown
+          ? (_) => _showReactionsDialog(context)
+          : null,
       child: Hero(
         tag: messageId,
         child: child,


### PR DESCRIPTION

Summary

This PR introduces right-click support (secondary mouse button) for opening the chat reactions and/or context menu when running on desktop and web platforms. The package previously only supported long-press (and optionally double-tap) as trigger mechanisms.

With this update, apps using a mouse can now invoke the reactions popup using the expected interaction model for desktop chat applications (e.g., Slack, Discord, Telegram Desktop).

⸻

Motivation

The original gesture model was optimized primarily for mobile usage. However, when integrating this package in a cross-platform chat app, right-click interaction is essential for desktop/web UX consistency.

This change enables developers to maintain the same reactions menu behavior across input devices without needing to fork or wrap the library externally.

⸻

What Was Changed
	•	Wrapped the message child with a Listener to detect pointer events.
	•	When enableRightClick is enabled and the event is:
	•	PointerDeviceKind.mouse
	•	kSecondaryMouseButton (right click)
→ the reactions/context menu is shown.
	•	Added enableRightClick field to ChatReactionsConfig with default false so behavior remains backward-compatible.


```
ChatReactionsConfig(
  enableLongPress: true,
  enableRightClick: true, //  this is new
)
```